### PR TITLE
Fix set indexing (non-existing operator)

### DIFF
--- a/src/ast_pattern_matching.nim
+++ b/src/ast_pattern_matching.nim
@@ -72,7 +72,8 @@ proc `$`*(arg: MatchingError): string =
     if k.len == 0:
       msg.add "any node"
     elif k.len == 1:
-      msg.add $k[0]
+      for el in k:  # only one element but there is no index op for sets
+        msg.add $el
     else:
       msg.add "a node in" & $k
 


### PR DESCRIPTION
Fixes: "Error: type mismatch: got <set[NimNodeKind], int literal(0)>" on k[0] where k is a set.

(by the way: awesome lib, this functionality was on my TODO list, actually)