### PR TITLE
Remove deprecated type pragma syntax

### DIFF
--- a/src/ast_pattern_matching.nim
+++ b/src/ast_pattern_matching.nim
@@ -572,7 +572,7 @@ when isMainModule:
         echo "got the ident m"
 
     testRecCase:
-      type Obj[T] = object {.inheritable.}
+      type Obj[T] {.inheritable.} = object
         name: string
         case isFat: bool
         of true:


### PR DESCRIPTION
ref https://github.com/nim-lang/Nim/commit/86f7f4ffa5b8d84cbff12afbcd9b88d3ceb429c8.
The devel tests of nimlsp fail because of this.