### PR TITLE
Move placement of inheritable pragma

### DIFF
--- a/src/ast_pattern_matching.nim
+++ b/src/ast_pattern_matching.nim
@@ -572,7 +572,7 @@ when isMainModule:
         echo "got the ident m"
 
     testRecCase:
-      type Obj[T] = object {.inheritable.}
+      type Obj[T] {.inheritable.} = object
         name: string
         case isFat: bool
         of true:


### PR DESCRIPTION
This moves the inheritable pragma after the type's name. Its previous placement is now deprecated on the latest releases of Nim.

Fixes #9 